### PR TITLE
Fix the ExpandOutputDir in XE6

### DIFF
--- a/DW.OTA.Helpers.pas
+++ b/DW.OTA.Helpers.pas
@@ -841,7 +841,7 @@ end;
 
 class function TOTAHelper.ExpandOutputDir(const ASource: string): string;
 begin
-  Result := ExpandProjectActiveConfiguration(ExpandVars(ASource), GetActiveProject);
+  Result := ExpandVars(ExpandProjectActiveConfiguration(ASource, GetActiveProject));
 end;
 
 class procedure TOTAHelper.ExpandPaths(const APaths: TStrings; const AProject: IOTAProject = nil);


### PR DESCRIPTION
The environment variable Platform is empty in Delphi XE6. Because of that, you need to ExpandProjectActiveConfiguration before ExpandVars.
The CnPack team also noticed the error and fixed it: https://github.com/cnpack/cnwizards/blob/ae44e3e04880d6169efc9aa4d6d9cf0eeb22b7c7/Source/Utils/CnWizUtils.pas#L1925